### PR TITLE
feat: add core type definitions

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -207,7 +207,7 @@ export interface SafeSnapshot {
 
 - [x] Initialize Vite + TypeScript project, ESLint, Prettier.
 - [x] Set up `index.html`, basic layout, and `app.css`.
-- [ ] Define TypeScript types (`types.d.ts`).
+- [x] Define TypeScript types (`types.d.ts`).
 
 ### B. State & Persistence
 
@@ -276,6 +276,7 @@ export interface SafeSnapshot {
 
 - 2025-09-12 • initialize Vite + TypeScript project, ESLint, Prettier, Wrangler setup • commit 361ee49
 - 2025-09-12 • set up basic layout with placeholder safe panel • commit 11b7b69
+- 2025-09-12 • define core TypeScript types • commit a49745c
 
 ---
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,30 @@
+export type Lang = 'en' | 'pl' | 'it';
+
+export interface SafeContent {
+  text: string;
+  imageDataUrl?: string; // Data URL representation
+}
+
+export interface SafeSettings {
+  language: Lang;
+  survivalEnabled: boolean; // 10% chance on destruction
+  autodestructMinutes?: number; // 1–999, undefined = disabled
+  pinAttemptsLimit?: number; // positive integer, undefined = unlimited
+}
+
+export type SafeState = 'open' | 'closed';
+
+export interface SafeRuntime {
+  state: SafeState;
+  pinHash?: string; // sha256 of pin
+  attemptsMade: number; // wrong attempts in current closed cycle
+  closedAt?: number; // epoch ms
+  destructAt?: number; // epoch ms, if timer armed
+}
+
+export interface SafeSnapshot {
+  id: string; // uuid
+  content: SafeContent;
+  settings: SafeSettings;
+  runtime: SafeRuntime;
+}


### PR DESCRIPTION
## Summary
- add core Safe state model types
- mark type definitions task complete in project board

## Testing
- `npm install` *(fails: 403 Forbidden for @typescript-eslint/eslint-plugin)*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c442eb19748327a913bfd7c347085b