### PR TITLE
feat: hash PIN via Web Crypto

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -212,7 +212,7 @@ export interface SafeSnapshot {
 ### B. State & Persistence
 
 - [ ] Implement `SafeSnapshot` state machine with events (open, close, wrongPin, tick, explode, survive).
-- [ ] PIN hashing via Web Crypto (sha256).
+- [x] PIN hashing via Web Crypto (sha256).
 - [ ] `localStorage` persistence with migration.
 - [ ] Timer handling (`destructAt`) with wake‑up check.
 
@@ -277,6 +277,7 @@ export interface SafeSnapshot {
 - 2025-09-12 • initialize Vite + TypeScript project, ESLint, Prettier, Wrangler setup • commit 361ee49
 - 2025-09-12 • set up basic layout with placeholder safe panel • commit 11b7b69
 - 2025-09-12 • define core TypeScript types • commit a49745c
+- 2025-09-12 • add PIN hashing via Web Crypto • commit 47ec345
 
 ---
 

--- a/src/pin.ts
+++ b/src/pin.ts
@@ -1,0 +1,10 @@
+export async function hashPin(pin: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(pin);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return hashHex;
+}


### PR DESCRIPTION
## Summary
- add async `hashPin` function that returns SHA-256 hex digest using Web Crypto
- check off task board item for PIN hashing and log commit

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c444ab447883279debc30c84ada69a