### PR TITLE
Implement destruct timer with wake-up check

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -214,7 +214,7 @@ export interface SafeSnapshot {
 - [ ] Implement `SafeSnapshot` state machine with events (open, close, wrongPin, tick, explode, survive).
 - [ ] PIN hashing via Web Crypto (sha256).
 - [ ] `localStorage` persistence with migration.
-- [ ] Timer handling (`destructAt`) with wake‑up check.
+- [x] Timer handling (`destructAt`) with wake‑up check.
 
 ### C. UI/UX
 
@@ -277,6 +277,8 @@ export interface SafeSnapshot {
 - 2025-09-12 • initialize Vite + TypeScript project, ESLint, Prettier, Wrangler setup • commit 361ee49
 - 2025-09-12 • set up basic layout with placeholder safe panel • commit 11b7b69
 - 2025-09-12 • define core TypeScript types • commit a49745c
+
+- 2025-09-12 • add destruct timer with wake-up check • commit 76073394
 
 ---
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
+import { startDestructTimer } from './timer';
+import type { SafeRuntime } from './types';
+
 const app = document.querySelector<HTMLDivElement>('#app');
 
 if (app) {
@@ -6,3 +9,15 @@ if (app) {
   panel.textContent = 'Safe panel placeholder';
   app.appendChild(panel);
 }
+
+// Demo: schedule a destruct timer 5 seconds from now when the safe is closed.
+const runtime: SafeRuntime = {
+  state: 'closed',
+  attemptsMade: 0,
+  destructAt: Date.now() + 5000,
+};
+
+startDestructTimer(runtime, () => {
+  // Placeholder explosion handler
+  console.log('Explosion! Timer elapsed.');
+});

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,0 +1,55 @@
+import type { SafeRuntime } from './types';
+
+export type ExplodeHandler = () => void;
+
+/**
+ * Starts a destruction timer based on `runtime.destructAt` and ensures the
+ * check runs again when the tab wakes up from being hidden or unfocused.
+ * Returns a cleanup function to cancel the timer and listeners.
+ */
+export function startDestructTimer(
+  runtime: SafeRuntime,
+  onExplode: ExplodeHandler,
+): () => void {
+  if (runtime.destructAt === undefined) {
+    return () => {
+      /* no timer armed */
+    };
+  }
+
+  let timeoutId: number | undefined;
+
+  const check = () => {
+    if (runtime.destructAt !== undefined && Date.now() >= runtime.destructAt) {
+      cleanup();
+      onExplode();
+    }
+  };
+
+  const schedule = () => {
+    const delay = runtime.destructAt! - Date.now();
+    if (delay <= 0) {
+      check();
+      return;
+    }
+    timeoutId = window.setTimeout(check, delay);
+  };
+
+  const onWake = () => check();
+
+  const cleanup = () => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+    document.removeEventListener('visibilitychange', onWake);
+    window.removeEventListener('focus', onWake);
+  };
+
+  schedule();
+  document.addEventListener('visibilitychange', onWake);
+  window.addEventListener('focus', onWake);
+
+  return cleanup;
+}
+


### PR DESCRIPTION
## Summary
- add `startDestructTimer` helper to schedule explosions and recheck on wake
- demo timer usage in `main.ts`
- update task board and changelog

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68c444b752d483279933ef57e12b3df9