### PR TITLE
Handle destruct timer with wake-up check

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -214,7 +214,7 @@ export interface SafeSnapshot {
 - [x] Implement `SafeSnapshot` state machine with events (open, close, wrongPin, tick, explode, survive).
 - [x] PIN hashing via Web Crypto (sha256).
 - [x] `localStorage` persistence with migration.
-- [ ] Timer handling (`destructAt`) with wake‑up check.
+- [x] Timer handling (`destructAt`) with wake‑up check.
 
 ### C. UI/UX
 
@@ -280,6 +280,7 @@ export interface SafeSnapshot {
 - 2025-09-12 • implement SafeSnapshot state machine • commit 82d8e61
 - 2025-09-12 • add PIN hashing via Web Crypto • commit 47ec345
 - 2025-09-12 • add localStorage persistence with migration • commit 6c91e1c
+- 2025-09-12 • handle destruct timer with wake-up check • commit 7dcdf3f
 
 ## 14) License
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,23 +1,55 @@
 import { loadSnapshot, saveSnapshot } from './persistence';
+import { reduce, spawnSafe, type SafeEvent } from './safeMachine';
 import type { SafeSnapshot } from './types';
 
-function createNewSnapshot(): SafeSnapshot {
-  return {
-    id: crypto.randomUUID(),
-    content: { text: '' },
-    settings: {
-      language: 'en',
-      survivalEnabled: false,
-    },
-    runtime: {
-      state: 'open',
-      attemptsMade: 0,
-    },
-  };
+let snapshot: SafeSnapshot = loadSnapshot() ?? spawnSafe();
+saveSnapshot(snapshot);
+
+function dispatch(event: SafeEvent): void {
+  const queue: SafeEvent[] = [event];
+  while (queue.length) {
+    const e = queue.shift()!;
+    const [next, emitted] = reduce(snapshot, e);
+    snapshot = next;
+    queue.push(...emitted);
+  }
+  saveSnapshot(snapshot);
+  scheduleTimer();
 }
 
-const snapshot = loadSnapshot() ?? createNewSnapshot();
-saveSnapshot(snapshot);
+let timerId: number | undefined;
+
+function scheduleTimer(): void {
+  if (timerId !== undefined) {
+    clearTimeout(timerId);
+    timerId = undefined;
+  }
+  if (
+    snapshot.runtime.state === 'closed' &&
+    snapshot.runtime.destructAt !== undefined
+  ) {
+    const delay = snapshot.runtime.destructAt - Date.now();
+    if (delay <= 0) {
+      dispatch({ type: 'tick', now: Date.now() });
+    } else {
+      timerId = window.setTimeout(() => {
+        dispatch({ type: 'tick', now: Date.now() });
+      }, delay);
+    }
+  }
+}
+
+scheduleTimer();
+
+window.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    dispatch({ type: 'tick', now: Date.now() });
+  }
+});
+
+window.addEventListener('focus', () => {
+  dispatch({ type: 'tick', now: Date.now() });
+});
 
 const app = document.querySelector<HTMLDivElement>('#app');
 


### PR DESCRIPTION
## Summary
- add auto-destruct timer management with wake-up check
- record task completion in project task board and changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext', missing `typescript-eslint`)*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint'; installation blocked)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4473157e48327bf2086f810e4cbbb