### PR TITLE
feat: add secret placeholder

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -290,6 +290,7 @@ export interface SafeSnapshot {
 - 2025-09-13 • skip Cloudflare deploy when token missing • commit 1ed03b5
 - 2025-09-13 • switch to worker deploy and assets binding • commit 11c7359
 - 2025-09-13 • fix assets directory field for worker deploy • commit 5a71ced
+- 2025-09-15 • add placeholder for textarea • commit 5510fd8
 
 ## 14) License
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ function renderOpen(): HTMLElement {
 
   const textarea = document.createElement('textarea');
   textarea.value = snapshot.content.text;
+  textarea.placeholder = 'Twój największy sekret';
   textarea.addEventListener('input', () => {
     snapshot.content.text = textarea.value;
     saveSnapshot(snapshot);


### PR DESCRIPTION
## Summary
- add placeholder text to safe textarea so users see "Twój największy sekret" before typing
- record changelog entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ConfigError: Unexpected key "0")*

------
https://chatgpt.com/codex/tasks/task_e_68c7d0df4ff483279ed27d12ff03dd86