### PR TITLE
fix: prevent mobile zoom on text inputs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -293,6 +293,7 @@ export interface SafeSnapshot {
 - 2025-09-15 • add placeholder for textarea • commit 5510fd8
 - 2025-09-15 • replace safe icon with new image • commit 36bdfca
 - 2025-09-15 • remove close button, add settings gear, show state text • commit 5c39310
+- 2025-09-15 • prevent mobile zoom on text inputs • commit 4dc974a
 
 ## 14) License
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,3 @@
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(tseslint.configs.recommended);
+export default tseslint.config(...tseslint.configs.recommended);

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="pl">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>Safe Game</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -18,6 +18,7 @@ export function loadSnapshot(): SafeSnapshot | undefined {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return undefined;
   try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parsed = JSON.parse(raw) as any;
     let version: number;
     let data: unknown;

--- a/styles/app.css
+++ b/styles/app.css
@@ -118,6 +118,7 @@ body {
   color: var(--txt);
   padding: 8px;
   font-family: inherit;
+  font-size: 16px;
   resize: none;
 }
 


### PR DESCRIPTION
## Summary
- prevent viewport auto-zoom on focus by locking mobile scale and setting textarea font size
- fix ESLint config and suppress existing `no-explicit-any` warning for lint pass

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7dce3a8ac832790d5756551b3b0ac