### PR TITLE
Add basic i18n with Polish and English strings

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,24 @@
+import type { Lang } from './types';
+import pl from './i18n/pl.json';
+import en from './i18n/en.json';
+
+export type MessageKey = keyof typeof pl;
+
+const messages: Record<Lang, Record<MessageKey, string>> = {
+  pl,
+  en,
+  // it will be added later when available
+};
+
+let currentLang: Lang = 'pl';
+
+export function setLang(lang: Lang): void {
+  if (messages[lang]) {
+    currentLang = lang;
+    document.documentElement.lang = lang;
+  }
+}
+
+export function t(key: MessageKey): string {
+  return messages[currentLang][key];
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,15 @@
+{
+  "closedNotImplemented": "Closed state not implemented",
+  "restartApp": "Restart app",
+  "safeOpen": "The safe is open",
+  "safeClosed": "The safe is closed",
+  "secretPlaceholder": "Your biggest secret",
+  "insertText": "Insert text",
+  "chooseImage": "Choose image",
+  "closeSafe": "Close safe",
+  "setPin": "Set PIN",
+  "confirmPin": "Confirm PIN",
+  "pinMismatch": "PIN does not match",
+  "ok": "OK",
+  "cancel": "Cancel"
+}

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,15 @@
+{
+  "closedNotImplemented": "Widok zamkniętego sejfu nie został jeszcze zaimplementowany",
+  "restartApp": "Restartuj aplikację",
+  "safeOpen": "Sejf jest otwarty",
+  "safeClosed": "Sejf jest zamknięty",
+  "secretPlaceholder": "Twój największy sekret",
+  "insertText": "Włóż tekst",
+  "chooseImage": "Wybierz obrazek",
+  "closeSafe": "Zamknij sejf",
+  "setPin": "Ustaw PIN",
+  "confirmPin": "Potwierdź PIN",
+  "pinMismatch": "PIN nie pasuje",
+  "ok": "OK",
+  "cancel": "Anuluj"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,10 @@ import { loadSnapshot, saveSnapshot } from './persistence';
 import { reduce, spawnSafe, type SafeEvent } from './safeMachine';
 import type { SafeSnapshot } from './types';
 import { hashPin } from './pin';
+import { t, setLang } from './i18n';
 
 let snapshot: SafeSnapshot = loadSnapshot() ?? spawnSafe();
+setLang(snapshot.settings.language);
 saveSnapshot(snapshot);
 
 function dispatch(event: SafeEvent): void {
@@ -12,6 +14,7 @@ function dispatch(event: SafeEvent): void {
     const e = queue.shift()!;
     const [next, emitted] = reduce(snapshot, e);
     snapshot = next;
+    setLang(snapshot.settings.language);
     queue.push(...emitted);
   }
   saveSnapshot(snapshot);
@@ -60,10 +63,10 @@ async function promptPin(message: string): Promise<string | null> {
     });
     const okBtn = document.createElement('button');
     okBtn.className = 'close-btn';
-    okBtn.textContent = 'OK';
+    okBtn.textContent = t('ok');
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'close-btn';
-    cancelBtn.textContent = 'Anuluj';
+    cancelBtn.textContent = t('cancel');
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') okBtn.click();
     });
@@ -100,11 +103,11 @@ function render(): void {
     const panel = document.createElement('div');
     panel.className = 'safe-panel';
     const text = document.createElement('p');
-    text.textContent = 'Closed state not implemented';
+    text.textContent = t('closedNotImplemented');
     panel.appendChild(text);
     const restartBtn = document.createElement('button');
     restartBtn.className = 'close-btn';
-    restartBtn.textContent = 'Restartuj aplikację';
+    restartBtn.textContent = t('restartApp');
     restartBtn.addEventListener('click', () => {
       localStorage.clear();
       location.reload();
@@ -136,8 +139,8 @@ function renderOpen(): HTMLElement {
   state.className = 'safe-state';
   state.textContent =
     snapshot.runtime.state === 'open'
-      ? 'Sejf jest otwarty'
-      : 'Sejf jest zamknięty';
+      ? t('safeOpen')
+      : t('safeClosed');
   panel.appendChild(state);
 
   const content = document.createElement('div');
@@ -163,21 +166,21 @@ function renderOpen(): HTMLElement {
 
   const textarea = document.createElement('textarea');
   textarea.value = snapshot.content.text;
-  textarea.placeholder = 'Twój największy sekret';
+  textarea.placeholder = t('secretPlaceholder');
   textarea.addEventListener('input', () => {
     snapshot.content.text = textarea.value;
     saveSnapshot(snapshot);
   });
 
   const textBtn = document.createElement('button');
-  textBtn.textContent = 'Włóż tekst';
+  textBtn.textContent = t('insertText');
   textBtn.addEventListener('click', () => {
     textarea.focus();
   });
   top.appendChild(textBtn);
 
   const imageBtn = document.createElement('button');
-  imageBtn.textContent = 'Wybierz obrazek';
+  imageBtn.textContent = t('chooseImage');
   imageBtn.addEventListener('click', () => fileInput.click());
   top.appendChild(imageBtn);
 
@@ -196,13 +199,13 @@ function renderOpen(): HTMLElement {
 
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
-  closeBtn.textContent = 'Zamknij sejf';
+  closeBtn.textContent = t('closeSafe');
   closeBtn.addEventListener('click', async () => {
-    const pin = await promptPin('Ustaw PIN');
+    const pin = await promptPin(t('setPin'));
     if (pin === null || pin === '') return;
-    const confirmPin = await promptPin('Potwierdź PIN');
+    const confirmPin = await promptPin(t('confirmPin'));
     if (confirmPin === null || confirmPin !== pin) {
-      alert('PIN nie pasuje');
+      alert(t('pinMismatch'));
       return;
     }
     const pinHash = await hashPin(pin);

--- a/src/safeMachine.ts
+++ b/src/safeMachine.ts
@@ -13,7 +13,7 @@ export function spawnSafe(): SafeSnapshot {
     id: crypto.randomUUID(),
     content: { text: '' },
     settings: {
-      language: 'en',
+      language: 'pl',
       survivalEnabled: false,
     },
     runtime: {


### PR DESCRIPTION
## Summary
- move existing UI labels into `src/i18n/pl.json`
- add English translations in `src/i18n/en.json`
- introduce simple `t` helper to load texts based on current language
- use translations throughout `main.ts` and default safe language to Polish

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe5495f88327adac575d3b9990b3