### PR TITLE
Add basic i18n with Polish and English strings

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,23 @@
+import type { Lang } from './types';
+import pl from './i18n/pl.json';
+import en from './i18n/en.json';
+
+export type MessageKey = keyof typeof pl;
+
+const messages: Record<Lang, Record<MessageKey, string>> = {
+  pl,
+  en,
+  // it will be added later when available
+};
+
+export const defaultLang: Lang = 'pl';
+let currentLang: Lang = defaultLang;
+
+export function setLang(lang?: Lang): void {
+  currentLang = lang && messages[lang] ? lang : defaultLang;
+  document.documentElement.lang = currentLang;
+}
+
+export function t(key: MessageKey): string {
+  return messages[currentLang][key];
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,15 @@
+{
+  "closedNotImplemented": "Closed state not implemented",
+  "restartApp": "Restart app",
+  "safeOpen": "The safe is open",
+  "safeClosed": "The safe is closed",
+  "secretPlaceholder": "Your biggest secret",
+  "insertText": "Insert text",
+  "chooseImage": "Choose image",
+  "closeSafe": "Close safe",
+  "setPin": "Set PIN",
+  "confirmPin": "Confirm PIN",
+  "pinMismatch": "PIN does not match",
+  "ok": "OK",
+  "cancel": "Cancel"
+}

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,15 @@
+{
+  "closedNotImplemented": "Widok zamkniętego sejfu nie został jeszcze zaimplementowany",
+  "restartApp": "Restartuj aplikację",
+  "safeOpen": "Sejf jest otwarty",
+  "safeClosed": "Sejf jest zamknięty",
+  "secretPlaceholder": "Twój największy sekret",
+  "insertText": "Włóż tekst",
+  "chooseImage": "Wybierz obrazek",
+  "closeSafe": "Zamknij sejf",
+  "setPin": "Ustaw PIN",
+  "confirmPin": "Potwierdź PIN",
+  "pinMismatch": "PIN nie pasuje",
+  "ok": "OK",
+  "cancel": "Anuluj"
+}

--- a/src/safeMachine.ts
+++ b/src/safeMachine.ts
@@ -13,7 +13,7 @@ export function spawnSafe(): SafeSnapshot {
     id: crypto.randomUUID(),
     content: { text: '' },
     settings: {
-      language: 'en',
+      language: 'pl',
       survivalEnabled: false,
     },
     runtime: {


### PR DESCRIPTION
## Summary
- move existing UI labels into `src/i18n/pl.json`
- add English translations in `src/i18n/en.json`
- introduce simple `t` helper to load texts based on current language
- use translations throughout `main.ts` and default safe language to Polish
- ensure snapshot falls back to Polish when language is missing or unsupported

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe5495f88327adac575d3b9990b3