### PR TITLE
feat: add settings modal

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -226,7 +226,7 @@ export interface SafeSnapshot {
 
 ### D. Settings & i18n
 
-- [ ] Settings modal (open‑only): language, timer minutes (1–999 or disabled), attempts limit (≥1 or disabled), survival checkbox.
+- [x] Settings modal (open‑only): language, timer minutes (1–999 or disabled), attempts limit (≥1 or disabled), survival checkbox.
 - [ ] i18n files: **en.json**, **pl.json**, **it.json** (100% coverage).
 - [ ] Language switcher (persists across sessions).
 
@@ -297,6 +297,7 @@ export interface SafeSnapshot {
 - 2025-09-15 • enlarge safe icon • commit 433a43a
 - 2025-09-15 • add close button and align safe panel • commit 2ab0094
 - 2025-09-15 • add restart button and numeric PIN dialog • commit 309e8a1
+- 2025-09-15 • add settings modal • commit b311f58
 
 ## 14) License
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -206,3 +206,45 @@ body {
   gap: 12px;
   justify-content: flex-end;
 }
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-dialog {
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--card-radius);
+  padding: 16px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-dialog label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-dialog input,
+.settings-dialog select {
+  background: var(--panel-bright);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: var(--txt);
+  padding: 8px;
+  font-size: 16px;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}


### PR DESCRIPTION
## Summary
- add settings modal with language, autodestruct timer, attempt limit, and survival toggle
- style settings overlay and dialog
- check off task board entry for settings modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80a22c9148327a82ebbaf590e9502