### PR TITLE
Add multilingual interface with PL/EN/IT translations

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -227,8 +227,8 @@ export interface SafeSnapshot {
 ### D. Settings & i18n
 
 - [x] Settings modal (open‑only): language, timer minutes (1–999 or disabled), attempts limit (≥1 or disabled), survival checkbox.
-- [ ] i18n files: **en.json**, **pl.json**, **it.json** (100% coverage).
-- [ ] Language switcher (persists across sessions).
+- [x] i18n files: **en.json**, **pl.json**, **it.json** (100% coverage).
+- [x] Language switcher (persists across sessions).
 
 ### E. Media Handling
 
@@ -299,6 +299,8 @@ export interface SafeSnapshot {
 - 2025-09-15 • add restart button and numeric PIN dialog • commit 309e8a1
 - 2025-09-15 • add settings modal • commit b311f58
 - 2025-09-15 • validate numeric settings inputs and avoid auto-focus on language • commit c1c2152
+- 2025-09-15 • add i18n files and language switcher • commit 72d365b
+- 2025-09-15 • refine language dialog to update in place • commit ae73e39
 
 ## 14) License
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pl">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,16 @@
+import en from './i18n/en.json';
+import pl from './i18n/pl.json';
+import it from './i18n/it.json';
+import type { Lang } from './types';
+
+const messages = { en, pl, it } as const;
+let current: Lang = 'en';
+
+export function setLang(lang: Lang): void {
+  current = lang;
+  document.documentElement.lang = lang;
+}
+
+export function t(key: keyof typeof en): string {
+  return messages[current][key];
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,21 @@
+{
+  "ok": "OK",
+  "cancel": "Cancel",
+  "closedStateNotImplemented": "Closed state not implemented",
+  "restartApp": "Restart application",
+  "language": "Language",
+  "autodestructMinutes": "Autodestruct (minutes)",
+  "valueRangeError": "Enter a value from 1-999",
+  "pinAttemptsLimit": "PIN attempt limit",
+  "survivalOption": "Content may survive explosion",
+  "save": "Save",
+  "safeOpen": "Safe is open",
+  "safeClosed": "Safe is closed",
+  "secretPlaceholder": "Your biggest secret",
+  "insertText": "Insert text",
+  "chooseImage": "Choose image",
+  "closeSafe": "Close safe",
+  "setPin": "Set PIN",
+  "confirmPin": "Confirm PIN",
+  "pinMismatch": "PINs do not match"
+}

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1,0 +1,21 @@
+{
+  "ok": "OK",
+  "cancel": "Annulla",
+  "closedStateNotImplemented": "Stato chiuso non implementato",
+  "restartApp": "Riavvia l'applicazione",
+  "language": "Lingua",
+  "autodestructMinutes": "Autodistruzione (minuti)",
+  "valueRangeError": "Inserisci un valore da 1 a 999",
+  "pinAttemptsLimit": "Limite tentativi PIN",
+  "survivalOption": "Il contenuto può sopravvivere all'esplosione",
+  "save": "Salva",
+  "safeOpen": "La cassaforte è aperta",
+  "safeClosed": "La cassaforte è chiusa",
+  "secretPlaceholder": "Il tuo segreto più grande",
+  "insertText": "Inserisci testo",
+  "chooseImage": "Scegli immagine",
+  "closeSafe": "Chiudi cassaforte",
+  "setPin": "Imposta PIN",
+  "confirmPin": "Conferma PIN",
+  "pinMismatch": "Il PIN non corrisponde"
+}

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,21 @@
+{
+  "ok": "OK",
+  "cancel": "Anuluj",
+  "closedStateNotImplemented": "Zamknięty stan nie jest zaimplementowany",
+  "restartApp": "Restartuj aplikację",
+  "language": "Język",
+  "autodestructMinutes": "Autodestrukcja (minuty)",
+  "valueRangeError": "Wprowadź wartość z zakresu 1-999",
+  "pinAttemptsLimit": "Limit prób PIN",
+  "survivalOption": "Treść może przetrwać eksplozję",
+  "save": "Zapisz",
+  "safeOpen": "Sejf jest otwarty",
+  "safeClosed": "Sejf jest zamknięty",
+  "secretPlaceholder": "Twój największy sekret",
+  "insertText": "Włóż tekst",
+  "chooseImage": "Wybierz obrazek",
+  "closeSafe": "Zamknij sejf",
+  "setPin": "Ustaw PIN",
+  "confirmPin": "Potwierdź PIN",
+  "pinMismatch": "PIN nie pasuje"
+}


### PR DESCRIPTION
## Summary
- add translation JSON files for English, Polish, and Italian
- introduce i18n utility and use it across the UI
- default document language to English
- apply language selection immediately when changing settings
- fix settings dialog to update language in place and preserve unsaved values

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c8153cf6548327b5b8ed48eeb287cc