### PR TITLE
Add manual explosion control and destroyed safe screen

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,5 +22,10 @@
   "openSafe": "Open safe",
   "attemptsRemaining": "Attempts remaining",
   "autodestructIn": "Autodestruct in",
-  "wrongPin": "Wrong PIN"
+  "wrongPin": "Wrong PIN",
+  "blowSafe": "Blow up safe",
+  "safeDestroyed": "The safe was destroyed",
+  "safeDestroyedDescription": "Everything inside is gone. Start over with a new safe.",
+  "startNewSafe": "Start new safe",
+  "contentSurvived": "The contents survived the explosion!"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -22,5 +22,10 @@
   "openSafe": "Apri cassaforte",
   "attemptsRemaining": "Tentativi rimasti",
   "autodestructIn": "Autodistruzione tra",
-  "wrongPin": "PIN errato"
+  "wrongPin": "PIN errato",
+  "blowSafe": "Fai esplodere la cassaforte",
+  "safeDestroyed": "La cassaforte è stata distrutta",
+  "safeDestroyedDescription": "Tutto il contenuto è andato perduto. Inizia con una nuova cassaforte.",
+  "startNewSafe": "Avvia nuova cassaforte",
+  "contentSurvived": "Il contenuto è sopravvissuto all'esplosione!"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -22,5 +22,10 @@
   "openSafe": "Otwórz sejf",
   "attemptsRemaining": "Pozostałe próby",
   "autodestructIn": "Autodestrukcja za",
-  "wrongPin": "Błędny PIN"
+  "wrongPin": "Błędny PIN",
+  "blowSafe": "Wysadź sejf",
+  "safeDestroyed": "Sejf został zniszczony",
+  "safeDestroyedDescription": "Wszystko w środku przepadło. Zacznij od nowego sejfu.",
+  "startNewSafe": "Rozpocznij nowy sejf",
+  "contentSurvived": "Zawartość przetrwała eksplozję!"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -272,8 +272,10 @@ function render(): void {
   app.innerHTML = '';
   if (snapshot.runtime.state === 'open') {
     app.appendChild(renderOpen());
-  } else {
+  } else if (snapshot.runtime.state === 'closed') {
     app.appendChild(renderClosed());
+  } else {
+    app.appendChild(renderDestroyed());
   }
 }
 
@@ -295,10 +297,7 @@ function renderOpen(): HTMLElement {
 
   const state = document.createElement('p');
   state.className = 'safe-state';
-    state.textContent =
-      snapshot.runtime.state === 'open'
-        ? t('safeOpen')
-        : t('safeClosed');
+  state.textContent = t('safeOpen');
   panel.appendChild(state);
 
   const content = document.createElement('div');
@@ -324,21 +323,21 @@ function renderOpen(): HTMLElement {
 
   const textarea = document.createElement('textarea');
   textarea.value = snapshot.content.text;
-    textarea.placeholder = t('secretPlaceholder');
+  textarea.placeholder = t('secretPlaceholder');
   textarea.addEventListener('input', () => {
     snapshot.content.text = textarea.value;
     saveSnapshot(snapshot);
   });
 
-    const textBtn = document.createElement('button');
-    textBtn.textContent = t('insertText');
+  const textBtn = document.createElement('button');
+  textBtn.textContent = t('insertText');
   textBtn.addEventListener('click', () => {
     textarea.focus();
   });
   top.appendChild(textBtn);
 
-    const imageBtn = document.createElement('button');
-    imageBtn.textContent = t('chooseImage');
+  const imageBtn = document.createElement('button');
+  imageBtn.textContent = t('chooseImage');
   imageBtn.addEventListener('click', () => fileInput.click());
   top.appendChild(imageBtn);
 
@@ -388,6 +387,13 @@ function renderClosed(): HTMLElement {
   state.className = 'safe-state';
   state.textContent = t('safeClosed');
   panel.appendChild(state);
+
+  if (snapshot.runtime.explosionResult === 'survived') {
+    const survived = document.createElement('p');
+    survived.className = 'explosion-message';
+    survived.textContent = t('contentSurvived');
+    panel.appendChild(survived);
+  }
 
   const label = document.createElement('label');
   label.textContent = t('enterPin');
@@ -444,6 +450,44 @@ function renderClosed(): HTMLElement {
     }
   });
   panel.appendChild(openBtn);
+
+  const blowBtn = document.createElement('button');
+  blowBtn.className = 'close-btn danger-btn';
+  blowBtn.textContent = t('blowSafe');
+  blowBtn.addEventListener('click', () => {
+    dispatch({ type: 'explode' });
+  });
+  panel.appendChild(blowBtn);
+
+  return panel;
+}
+
+function renderDestroyed(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'safe-panel destroyed-panel';
+
+  const emoji = document.createElement('div');
+  emoji.className = 'destroyed-emoji';
+  emoji.textContent = '💥';
+  panel.appendChild(emoji);
+
+  const title = document.createElement('h2');
+  title.className = 'destroyed-title';
+  title.textContent = t('safeDestroyed');
+  panel.appendChild(title);
+
+  const description = document.createElement('p');
+  description.className = 'destroyed-text';
+  description.textContent = t('safeDestroyedDescription');
+  panel.appendChild(description);
+
+  const newSafeBtn = document.createElement('button');
+  newSafeBtn.className = 'close-btn';
+  newSafeBtn.textContent = t('startNewSafe');
+  newSafeBtn.addEventListener('click', () => {
+    dispatch({ type: 'startNew' });
+  });
+  panel.appendChild(newSafeBtn);
 
   return panel;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,7 +12,7 @@ export interface SafeSettings {
   pinAttemptsLimit?: number; // positive integer, undefined = unlimited
 }
 
-export type SafeState = 'open' | 'closed';
+export type SafeState = 'open' | 'closed' | 'destroyed';
 
 export interface SafeRuntime {
   state: SafeState;
@@ -20,6 +20,7 @@ export interface SafeRuntime {
   attemptsMade: number; // wrong attempts in current closed cycle
   closedAt?: number; // epoch ms
   destructAt?: number; // epoch ms, if timer armed
+  explosionResult?: 'survived' | 'destroyed';
 }
 
 export interface SafeSnapshot {

--- a/styles/app.css
+++ b/styles/app.css
@@ -127,6 +127,18 @@ body {
   box-shadow: inset 0 0 8px rgba(45, 212, 191, 0.6);
 }
 
+.danger-btn {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.4);
+  box-shadow: inset 0 0 12px rgba(248, 113, 113, 0.45);
+  color: #fecaca;
+}
+
+.danger-btn:hover {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: inset 0 0 12px rgba(248, 113, 113, 0.65);
+}
+
 .safe-content textarea {
   flex: 1;
   width: 100%;
@@ -216,6 +228,13 @@ body {
   margin: 0;
 }
 
+.explosion-message {
+  margin: 0;
+  text-align: center;
+  font-weight: 600;
+  color: #34d399;
+}
+
 .pin-actions {
   display: flex;
   gap: 12px;
@@ -267,4 +286,26 @@ body {
   display: flex;
   gap: 12px;
   justify-content: flex-end;
+}
+
+.destroyed-panel {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.destroyed-emoji {
+  font-size: 72px;
+  line-height: 1;
+}
+
+.destroyed-title {
+  margin: 0;
+  font-size: 28px;
+}
+
+.destroyed-text {
+  margin: 0;
+  max-width: 420px;
+  color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- add a manual "Blow up safe" control to the closed safe view and show survival feedback when content endures an explosion
- extend the state machine with a destroyed state and start-new event so explosions can surface a dedicated destroyed screen
- style the destroyed state, add the necessary translations, and provide a call to create a fresh safe
- preserve the player's selected language when spawning a new safe after destruction

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c83c419ab88327b0e0db7a58be6711