### PR TITLE
Add modal for inserting text content into the safe

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,6 +12,7 @@
   "safeOpen": "Safe is open",
   "safeClosed": "Safe is closed",
   "secretPlaceholder": "Your biggest secret",
+  "textDialogTitle": "Insert text into the safe",
   "insertText": "Insert text",
   "chooseImage": "Choose image",
   "closeSafe": "Close safe",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -12,6 +12,7 @@
   "safeOpen": "La cassaforte è aperta",
   "safeClosed": "La cassaforte è chiusa",
   "secretPlaceholder": "Il tuo segreto più grande",
+  "textDialogTitle": "Inserisci il testo nella cassaforte",
   "insertText": "Inserisci testo",
   "chooseImage": "Scegli immagine",
   "closeSafe": "Chiudi cassaforte",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -12,6 +12,7 @@
   "safeOpen": "Sejf jest otwarty",
   "safeClosed": "Sejf jest zamknięty",
   "secretPlaceholder": "Twój największy sekret",
+  "textDialogTitle": "Włóż tekst do sejfu",
   "insertText": "Włóż tekst",
   "chooseImage": "Wybierz obrazek",
   "closeSafe": "Zamknij sejf",

--- a/styles/app.css
+++ b/styles/app.css
@@ -288,6 +288,26 @@ body {
   justify-content: flex-end;
 }
 
+.text-dialog {
+  width: min(480px, 90vw);
+}
+
+.text-dialog-title {
+  margin: 0;
+}
+
+.text-dialog textarea {
+  min-height: 160px;
+  background: var(--panel-bright);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  color: var(--txt);
+  padding: 8px;
+  font-family: inherit;
+  font-size: 16px;
+  resize: vertical;
+}
+
 .destroyed-panel {
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- add a modal dialog that lets players insert text into the safe content
- refresh translations and styling to support the new dialog experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85390be508327b1e56d90b5931152