### PR TITLE
Improve settings button styling and safe state emphasis

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -9,6 +9,7 @@
   "pinAttemptsLimit": "PIN attempt limit",
   "survivalOption": "Content may survive explosion",
   "save": "Save",
+  "settings": "Settings",
   "safeOpen": "Safe is open",
   "safeClosed": "Safe is closed",
   "secretPlaceholder": "Your biggest secret",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -9,6 +9,7 @@
   "pinAttemptsLimit": "Limite tentativi PIN",
   "survivalOption": "Il contenuto può sopravvivere all'esplosione",
   "save": "Salva",
+  "settings": "Impostazioni",
   "safeOpen": "La cassaforte è aperta",
   "safeClosed": "La cassaforte è chiusa",
   "secretPlaceholder": "Il tuo segreto più grande",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -9,6 +9,7 @@
   "pinAttemptsLimit": "Limit prób PIN",
   "survivalOption": "Treść może przetrwać eksplozję",
   "save": "Zapisz",
+  "settings": "Ustawienia",
   "safeOpen": "Sejf jest otwarty",
   "safeClosed": "Sejf jest zamknięty",
   "secretPlaceholder": "Twój największy sekret",

--- a/src/main.ts
+++ b/src/main.ts
@@ -285,7 +285,10 @@ function renderOpen(): HTMLElement {
 
   const settingsBtn = document.createElement('button');
   settingsBtn.className = 'settings-icon';
+  settingsBtn.type = 'button';
   settingsBtn.textContent = '⚙️';
+  settingsBtn.setAttribute('aria-label', t('settings'));
+  settingsBtn.title = t('settings');
   settingsBtn.addEventListener('click', openSettings);
   panel.appendChild(settingsBtn);
 
@@ -296,7 +299,7 @@ function renderOpen(): HTMLElement {
   panel.appendChild(icon);
 
   const state = document.createElement('p');
-  state.className = 'safe-state';
+  state.className = 'safe-state safe-state--open';
   state.textContent = t('safeOpen');
   panel.appendChild(state);
 
@@ -384,7 +387,7 @@ function renderClosed(): HTMLElement {
   panel.appendChild(icon);
 
   const state = document.createElement('p');
-  state.className = 'safe-state';
+  state.className = 'safe-state safe-state--closed';
   state.textContent = t('safeClosed');
   panel.appendChild(state);
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&display=swap');
+
 :root {
   --bg: #0b0d10;
   --panel: rgba(255, 255, 255, 0.06);
@@ -169,20 +171,75 @@ body {
   position: absolute;
   top: 12px;
   right: 12px;
-  background: none;
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 12px;
+  background: var(--panel-bright);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--txt);
-  font-size: 20px;
+  font-size: 22px;
   cursor: pointer;
+  box-shadow: inset 0 0 8px rgba(45, 212, 191, 0.4);
+  transition:
+    box-shadow 0.2s,
+    border-color 0.2s,
+    transform 0.2s;
 }
 
 .settings-icon:hover {
-  opacity: 0.8;
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 12px rgba(45, 212, 191, 0.6);
+  transform: translateY(-1px);
+}
+
+.settings-icon:focus-visible {
+  outline: 2px solid rgba(45, 212, 191, 0.8);
+  outline-offset: 3px;
 }
 
 .safe-state {
-  text-align: center;
   margin: 0;
+  align-self: center;
+  margin-inline: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 10px 24px;
+  border-radius: 999px;
+  font-family: 'Orbitron', 'Inter', system-ui, -apple-system, 'Segoe UI',
+    Roboto, Ubuntu, Cantarell, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+  font-size: 20px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: linear-gradient(
+    120deg,
+    rgba(45, 212, 191, 0.2),
+    rgba(138, 92, 246, 0.18)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow:
+    inset 0 0 18px rgba(45, 212, 191, 0.3),
+    0 12px 26px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 0 18px rgba(45, 212, 191, 0.6);
+}
+
+.safe-state--open {
+  color: #5eead4;
+}
+
+.safe-state--closed {
+  color: #c4b5fd;
+  text-shadow: 0 0 18px rgba(138, 92, 246, 0.6);
+  background: linear-gradient(
+    120deg,
+    rgba(138, 92, 246, 0.22),
+    rgba(45, 212, 191, 0.16)
+  );
 }
 
 .pin-overlay {


### PR DESCRIPTION
## Summary
- restyle the floating settings icon to share the safe panel button chrome and provide accessible labels
- emphasise the safe state indicator with a techno font, pill badge styling, centred alignment, and distinct open/closed colour accents
- expose a new i18n key for the settings label across Polish, English, and Italian locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8ff47647c8327a740cc1252768cf6