### PR TITLE
Fix countdown refresh behaviour and add low-time warning

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -285,6 +285,11 @@ body {
   margin: 0;
 }
 
+.countdown-warning {
+  color: #f87171;
+  font-weight: 600;
+}
+
 .explosion-message {
   margin: 0;
   text-align: center;


### PR DESCRIPTION
## Summary
- update the countdown scheduler to only refresh the timer text instead of re-rendering the whole view
- add helpers that refresh countdown labels and highlight them in red when less than 10% of the time remains
- style the new countdown warning state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9045c79a8832780eaf59f382cbab7