### PR TITLE
Add about dialog and info icon

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,5 +31,11 @@
   "safeDestroyed": "The safe was destroyed",
   "safeDestroyedDescription": "Everything inside is gone. Start over with a new safe.",
   "startNewSafe": "Start new safe",
-  "contentSurvived": "The contents survived the explosion!"
+  "contentSurvived": "The contents survived the explosion!",
+  "about": "About",
+  "aboutTitle": "What is this project?",
+  "aboutIntro": "Safe Game is a tiny web toy where you manage a virtual safe. While it's open you can stash text or an image, then seal it with your own PIN.",
+  "aboutHow": "Experiment with timers, attempt limits, and survival chance to see how long your secrets last before the safe explodes.",
+  "aboutNote": "It's purely for fun—do not rely on it for real security.",
+  "close": "Close"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -31,5 +31,11 @@
   "safeDestroyed": "La cassaforte è stata distrutta",
   "safeDestroyedDescription": "Tutto il contenuto è andato perduto. Inizia con una nuova cassaforte.",
   "startNewSafe": "Avvia nuova cassaforte",
-  "contentSurvived": "Il contenuto è sopravvissuto all'esplosione!"
+  "contentSurvived": "Il contenuto è sopravvissuto all'esplosione!",
+  "about": "Informazioni",
+  "aboutTitle": "Di cosa parla questo progetto?",
+  "aboutIntro": "Safe Game è un piccolo gioco web in cui gestisci una cassaforte virtuale. Quando è aperta puoi salvare testo o un'immagine e poi chiuderla con il tuo PIN.",
+  "aboutHow": "Sperimenta con il timer di autodistruzione, il limite di tentativi e la probabilità di sopravvivenza per vedere quanto a lungo resistono i tuoi segreti prima dell'esplosione.",
+  "aboutNote": "È solo un gioco: non fare affidamento sul PIN per una vera sicurezza.",
+  "close": "Chiudi"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -31,5 +31,11 @@
   "safeDestroyed": "Sejf został zniszczony",
   "safeDestroyedDescription": "Wszystko w środku przepadło. Zacznij od nowego sejfu.",
   "startNewSafe": "Rozpocznij nowy sejf",
-  "contentSurvived": "Zawartość przetrwała eksplozję!"
+  "contentSurvived": "Zawartość przetrwała eksplozję!",
+  "about": "O projekcie",
+  "aboutTitle": "O co chodzi w tym projekcie?",
+  "aboutIntro": "Safe Game to mała gra przeglądarkowa, w której zarządzasz wirtualnym sejfem. Gdy sejf jest otwarty, możesz schować tekst lub obrazek, a potem zamknąć go własnym PIN-em.",
+  "aboutHow": "Eksperymentuj z timerem autodestrukcji, limitem prób oraz szansą przetrwania, żeby sprawdzić, jak długo utrzymasz swoje sekrety przed eksplozją.",
+  "aboutNote": "To tylko zabawa — nie traktuj PIN-u jako prawdziwego zabezpieczenia.",
+  "close": "Zamknij"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,6 +304,70 @@ function openSettings(): void {
   });
 }
 
+function openAbout(): void {
+  const overlay = document.createElement('div');
+  overlay.className = 'settings-overlay';
+  const dialog = document.createElement('div');
+  dialog.className = 'info-dialog';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', t('about'));
+  dialog.tabIndex = -1;
+
+  const title = document.createElement('h2');
+  title.textContent = t('aboutTitle');
+  dialog.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.textContent = t('aboutIntro');
+  dialog.appendChild(intro);
+
+  const how = document.createElement('p');
+  how.textContent = t('aboutHow');
+  dialog.appendChild(how);
+
+  const note = document.createElement('p');
+  note.className = 'info-note';
+  note.textContent = t('aboutNote');
+  dialog.appendChild(note);
+
+  const actions = document.createElement('div');
+  actions.className = 'settings-actions';
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'close-btn';
+  closeBtn.textContent = t('close');
+  actions.appendChild(closeBtn);
+  dialog.appendChild(actions);
+
+  overlay.appendChild(dialog);
+
+  function cleanup(): void {
+    if (overlay.parentNode) {
+      overlay.parentNode.removeChild(overlay);
+    }
+    document.removeEventListener('keydown', onKeyDown);
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cleanup();
+    }
+  }
+
+  closeBtn.addEventListener('click', cleanup);
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      cleanup();
+    }
+  });
+  document.addEventListener('keydown', onKeyDown);
+
+  document.body.appendChild(overlay);
+  dialog.focus();
+}
+
 function render(): void {
   if (!app) return;
   app.innerHTML = '';
@@ -372,14 +436,28 @@ function renderOpen(): HTMLElement {
   const panel = document.createElement('div');
   panel.className = 'safe-panel';
 
+  const icons = document.createElement('div');
+  icons.className = 'panel-icons';
+
+  const infoBtn = document.createElement('button');
+  infoBtn.type = 'button';
+  infoBtn.className = 'panel-icon-button info-icon';
+  infoBtn.textContent = 'ℹ️';
+  infoBtn.setAttribute('aria-label', t('about'));
+  infoBtn.title = t('about');
+  infoBtn.addEventListener('click', openAbout);
+  icons.appendChild(infoBtn);
+
   const settingsBtn = document.createElement('button');
-  settingsBtn.className = 'settings-icon';
   settingsBtn.type = 'button';
+  settingsBtn.className = 'panel-icon-button settings-icon';
   settingsBtn.textContent = '⚙️';
   settingsBtn.setAttribute('aria-label', t('settings'));
   settingsBtn.title = t('settings');
   settingsBtn.addEventListener('click', openSettings);
-  panel.appendChild(settingsBtn);
+  icons.appendChild(settingsBtn);
+
+  panel.appendChild(icons);
 
   const icon = document.createElement('img');
   icon.src = '/safe.webp';

--- a/styles/app.css
+++ b/styles/app.css
@@ -252,10 +252,15 @@ body {
   line-height: 1;
 }
 
-.settings-icon {
+.panel-icons {
   position: absolute;
   top: 12px;
   right: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+.panel-icon-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -275,13 +280,13 @@ body {
     transform 0.2s;
 }
 
-.settings-icon:hover {
+.panel-icon-button:hover {
   border-color: rgba(255, 255, 255, 0.16);
   box-shadow: inset 0 0 12px rgba(45, 212, 191, 0.6);
   transform: translateY(-1px);
 }
 
-.settings-icon:focus-visible {
+.panel-icon-button:focus-visible {
   outline: 2px solid rgba(45, 212, 191, 0.8);
   outline-offset: 3px;
 }
@@ -433,6 +438,33 @@ body {
   display: flex;
   gap: 12px;
   justify-content: flex-end;
+}
+
+.info-dialog {
+  background: var(--panel-solid);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--card-radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-dialog h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.info-dialog p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.info-note {
+  color: #5eead4;
+  font-weight: 600;
 }
 
 .destroyed-panel {


### PR DESCRIPTION
## Summary
- add an info icon next to the settings button that opens an about dialog
- describe the project and its goals in the new dialog across PL/EN/IT translations
- share button styling for panel icons and add styles for the about dialog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff862e864832786b94a1b0aa0a7b8