### PR TITLE
Improve settings toggles visuals and remember last values

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -194,26 +194,34 @@ function openSettings(): void {
   autoErr.className = 'settings-error';
   autoRow.appendChild(autoErr);
   const autoEnabled = snapshot.settings.autodestructMinutes !== undefined;
+  const autoRememberedValue =
+    snapshot.settings.autodestructMinutesRemembered ??
+    snapshot.settings.autodestructMinutes ??
+    90;
+  const initialAutoValue = autoEnabled
+    ? snapshot.settings.autodestructMinutes ?? autoRememberedValue
+    : autoRememberedValue;
   autoToggle.checked = autoEnabled;
-  autoInput.value = autoEnabled
-    ? String(snapshot.settings.autodestructMinutes)
-    : '90';
+  autoInput.value = String(initialAutoValue);
   autoInput.disabled = !autoEnabled;
+
+  let autoStored = autoInput.value;
 
   autoToggle.addEventListener('change', () => {
     if (autoToggle.checked) {
       autoInput.disabled = false;
-      autoInput.value = '90';
+      autoInput.value = autoStored;
       autoErr.textContent = '';
       autoInput.focus();
     } else {
+      autoStored = autoInput.value.trim() || autoStored;
       autoInput.disabled = true;
-      autoInput.value = '90';
       autoErr.textContent = '';
     }
   });
 
   autoInput.addEventListener('input', () => {
+    autoStored = autoInput.value;
     if (!autoToggle.checked) {
       autoErr.textContent = '';
       return;
@@ -262,26 +270,34 @@ function openSettings(): void {
   limitErr.className = 'settings-error';
   limitRow.appendChild(limitErr);
   const limitEnabled = snapshot.settings.pinAttemptsLimit !== undefined;
+  const limitRememberedValue =
+    snapshot.settings.pinAttemptsLimitRemembered ??
+    snapshot.settings.pinAttemptsLimit ??
+    3;
+  const initialLimitValue = limitEnabled
+    ? snapshot.settings.pinAttemptsLimit ?? limitRememberedValue
+    : limitRememberedValue;
   limitToggle.checked = limitEnabled;
-  limitInput.value = limitEnabled
-    ? String(snapshot.settings.pinAttemptsLimit)
-    : '3';
+  limitInput.value = String(initialLimitValue);
   limitInput.disabled = !limitEnabled;
+
+  let limitStored = limitInput.value;
 
   limitToggle.addEventListener('change', () => {
     if (limitToggle.checked) {
       limitInput.disabled = false;
-      limitInput.value = '3';
+      limitInput.value = limitStored;
       limitErr.textContent = '';
       limitInput.focus();
     } else {
+      limitStored = limitInput.value.trim() || limitStored;
       limitInput.disabled = true;
-      limitInput.value = '3';
       limitErr.textContent = '';
     }
   });
 
   limitInput.addEventListener('input', () => {
+    limitStored = limitInput.value;
     if (!limitToggle.checked) {
       limitErr.textContent = '';
       return;
@@ -335,25 +351,34 @@ function openSettings(): void {
   survivalErr.className = 'settings-error';
   survivalRow.appendChild(survivalErr);
   const survivalEnabled = snapshot.settings.survivalEnabled;
-  const survivalChance = snapshot.settings.survivalChance ?? 10;
+  const survivalRememberedValue =
+    snapshot.settings.survivalChanceRemembered ??
+    snapshot.settings.survivalChance ??
+    10;
+  const initialSurvivalValue = survivalEnabled
+    ? snapshot.settings.survivalChance ?? survivalRememberedValue
+    : survivalRememberedValue;
   survivalToggle.checked = survivalEnabled;
-  survivalInput.value = survivalEnabled ? String(survivalChance) : '10';
+  survivalInput.value = String(initialSurvivalValue);
   survivalInput.disabled = !survivalEnabled;
+
+  let survivalStored = survivalInput.value;
 
   survivalToggle.addEventListener('change', () => {
     if (survivalToggle.checked) {
       survivalInput.disabled = false;
-      survivalInput.value = '10';
+      survivalInput.value = survivalStored;
       survivalErr.textContent = '';
       survivalInput.focus();
     } else {
+      survivalStored = survivalInput.value.trim() || survivalStored;
       survivalInput.disabled = true;
-      survivalInput.value = '10';
       survivalErr.textContent = '';
     }
   });
 
   survivalInput.addEventListener('input', () => {
+    survivalStored = survivalInput.value;
     if (!survivalToggle.checked) {
       survivalErr.textContent = '';
       return;
@@ -432,49 +457,55 @@ function openSettings(): void {
     e.preventDefault();
     let focusTarget: HTMLInputElement | undefined;
 
+    const autoRaw = autoInput.value.trim();
+    const autoVal = Number(autoRaw);
+    const autoValid =
+      autoRaw !== '' &&
+      Number.isInteger(autoVal) &&
+      autoVal >= 1 &&
+      autoVal <= 999;
     if (autoToggle.checked) {
-      const raw = autoInput.value.trim();
-      const val = Number(raw);
-      if (
-        raw === '' ||
-        !Number.isInteger(val) ||
-        val < 1 ||
-        val > 999
-      ) {
+      if (!autoValid) {
         autoErr.textContent = t('valueRangeError');
         focusTarget = focusTarget ?? autoInput;
+      } else {
+        autoErr.textContent = '';
       }
     } else {
       autoErr.textContent = '';
     }
 
+    const limitRaw = limitInput.value.trim();
+    const limitVal = Number(limitRaw);
+    const limitValid =
+      limitRaw !== '' &&
+      Number.isInteger(limitVal) &&
+      limitVal >= 1 &&
+      limitVal <= 999;
     if (limitToggle.checked) {
-      const raw = limitInput.value.trim();
-      const val = Number(raw);
-      if (
-        raw === '' ||
-        !Number.isInteger(val) ||
-        val < 1 ||
-        val > 999
-      ) {
+      if (!limitValid) {
         limitErr.textContent = t('valueRangeError');
         focusTarget = focusTarget ?? limitInput;
+      } else {
+        limitErr.textContent = '';
       }
     } else {
       limitErr.textContent = '';
     }
 
+    const survivalRaw = survivalInput.value.trim();
+    const survivalVal = Number(survivalRaw);
+    const survivalValid =
+      survivalRaw !== '' &&
+      Number.isInteger(survivalVal) &&
+      survivalVal >= 1 &&
+      survivalVal <= 100;
     if (survivalToggle.checked) {
-      const raw = survivalInput.value.trim();
-      const val = Number(raw);
-      if (
-        raw === '' ||
-        !Number.isInteger(val) ||
-        val < 1 ||
-        val > 100
-      ) {
+      if (!survivalValid) {
         survivalErr.textContent = t('percentageRangeError');
         focusTarget = focusTarget ?? survivalInput;
+      } else {
+        survivalErr.textContent = '';
       }
     } else {
       survivalErr.textContent = '';
@@ -487,16 +518,22 @@ function openSettings(): void {
 
     snapshot.settings.language = langSelect.value as Lang;
     setLang(snapshot.settings.language);
-    snapshot.settings.autodestructMinutes = autoToggle.checked
-      ? Number(autoInput.value.trim())
-      : undefined;
-    snapshot.settings.pinAttemptsLimit = limitToggle.checked
-      ? Number(limitInput.value.trim())
-      : undefined;
+    if (autoValid) {
+      snapshot.settings.autodestructMinutesRemembered = autoVal;
+    }
+    snapshot.settings.autodestructMinutes =
+      autoToggle.checked && autoValid ? autoVal : undefined;
+    if (limitValid) {
+      snapshot.settings.pinAttemptsLimitRemembered = limitVal;
+    }
+    snapshot.settings.pinAttemptsLimit =
+      limitToggle.checked && limitValid ? limitVal : undefined;
     snapshot.settings.survivalEnabled = survivalToggle.checked;
-    snapshot.settings.survivalChance = survivalToggle.checked
-      ? Number(survivalInput.value.trim())
-      : undefined;
+    if (survivalValid) {
+      snapshot.settings.survivalChanceRemembered = survivalVal;
+    }
+    snapshot.settings.survivalChance =
+      survivalToggle.checked && survivalValid ? survivalVal : undefined;
     saveSnapshot(snapshot);
     cleanup();
   });

--- a/src/safeMachine.ts
+++ b/src/safeMachine.ts
@@ -17,6 +17,9 @@ export function spawnSafe(language: Lang = 'en'): SafeSnapshot {
       language,
       survivalEnabled: false,
       survivalChance: 10,
+      survivalChanceRemembered: 10,
+      autodestructMinutesRemembered: 90,
+      pinAttemptsLimitRemembered: 3,
     },
     runtime: {
       state: 'open',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,8 +9,11 @@ export interface SafeSettings {
   language: Lang;
   survivalEnabled: boolean; // survival chance active when true
   survivalChance?: number; // 1–100 percent chance on destruction
+  survivalChanceRemembered?: number; // last entered survival chance value
   autodestructMinutes?: number; // 1–999, undefined = disabled
+  autodestructMinutesRemembered?: number; // stored even when disabled
   pinAttemptsLimit?: number; // positive integer, undefined = unlimited
+  pinAttemptsLimitRemembered?: number; // stored even when disabled
 }
 
 export type SafeState = 'open' | 'closed' | 'destroyed';

--- a/styles/app.css
+++ b/styles/app.css
@@ -462,38 +462,48 @@ body {
   --toggle-width: 44px;
   --toggle-height: 24px;
   --toggle-padding: 3px;
-  --toggle-knob-size: calc(var(--toggle-height) - 2 * var(--toggle-padding));
-  --toggle-shift: calc(var(--toggle-width) - 2 * var(--toggle-padding) - var(--toggle-knob-size));
+  --toggle-border: 1px;
+  --toggle-knob-size: calc(
+    var(--toggle-height) - 2 * (var(--toggle-padding) + var(--toggle-border))
+  );
+  --toggle-shift: calc(
+    var(--toggle-width) - 2 * (var(--toggle-padding) + var(--toggle-border)) -
+      var(--toggle-knob-size)
+  );
   appearance: none;
   width: var(--toggle-width);
   height: var(--toggle-height);
   box-sizing: border-box;
-  border-radius: calc(var(--toggle-height) / 2);
-  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: var(--toggle-height);
+  border: var(--toggle-border) solid rgba(255, 255, 255, 0.24);
   background: rgba(255, 255, 255, 0.12);
   position: relative;
   cursor: pointer;
+  padding: 0;
   transition:
     background 0.2s ease,
-    border-color 0.2s ease;
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .settings-toggle::after {
   content: '';
   position: absolute;
   top: 50%;
-  left: var(--toggle-padding);
+  left: calc(var(--toggle-border) + var(--toggle-padding));
   width: var(--toggle-knob-size);
   height: var(--toggle-knob-size);
   border-radius: 50%;
   background: #fff;
   transform: translate(0, -50%);
   transition: transform 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.32);
 }
 
 .settings-toggle:checked {
   background: var(--brand);
   border-color: var(--brand);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .settings-toggle:checked::after {


### PR DESCRIPTION
## Summary
- smooth out the settings toggle styling so the track ends are round and the knob stays centered
- keep autodestruct, attempt limit, and survival chance inputs disabled without losing their last values when toggles flip off
- persist the most recent values so toggles restore user-provided numbers instead of defaults when re-enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00a4ce3848327a5f996e847c1a585