### PR TITLE
Extend background gradient to top edge

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -33,9 +33,13 @@ body {
     ),
     var(--bg);
   background-repeat: no-repeat, no-repeat, no-repeat;
+  background-position:
+    left top,
+    right top,
+    left top;
   background-size:
-    160% 90%,
-    140% 80%,
+    160% 120%,
+    140% 110%,
     auto;
   color: var(--txt);
   font-family:


### PR DESCRIPTION
## Summary
- adjust the body background positioning so the gradient fills the page from the top edge
- expand the background sizes to eliminate the dark strip above the main panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02b3b4b108327bfc1540aa0fa6b9c