### PR TITLE
Extend background into mobile safe areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
+    <meta name="theme-color" content="#0b0d10" />
     <title>Safe Game</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/styles/app.css
+++ b/styles/app.css
@@ -11,16 +11,7 @@
   --brand-2: #2dd4bf;
   --card-radius: 18px;
   --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  height: 100vh;
-  background:
+  --page-background:
     radial-gradient(
       1200px 600px at 15% -10%,
       rgba(138, 92, 246, 0.28),
@@ -32,11 +23,27 @@ body {
       transparent 60%
     ),
     var(--bg);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  background: var(--page-background);
   background-repeat: no-repeat, no-repeat, no-repeat;
   background-size:
     160% 90%,
     140% 80%,
     auto;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  min-height: 100vh;
+  min-height: 100dvh;
   color: var(--txt);
   font-family:
     'Inter',
@@ -61,9 +68,27 @@ body {
   padding: 48px 16px;
 }
 
+@supports (padding-top: env(safe-area-inset-top)) {
+  #app {
+    padding-top: calc(48px + env(safe-area-inset-top));
+    padding-right: calc(16px + env(safe-area-inset-right));
+    padding-bottom: calc(48px + env(safe-area-inset-bottom));
+    padding-left: calc(16px + env(safe-area-inset-left));
+  }
+}
+
 @media (max-width: 600px) {
   #app {
     padding: 24px 12px;
+  }
+
+  @supports (padding-top: env(safe-area-inset-top)) {
+    #app {
+      padding-top: calc(24px + env(safe-area-inset-top));
+      padding-right: calc(12px + env(safe-area-inset-right));
+      padding-bottom: calc(24px + env(safe-area-inset-bottom));
+      padding-left: calc(12px + env(safe-area-inset-left));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- allow the viewport to cover the mobile safe area and match the status bar color to the background
- move the gradient background definition to the root element and apply safe-area padding to the app container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0331a49588327a9c066ac0540139d