### PR TITLE
Improve mobile safe area layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,11 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
+    <meta name="theme-color" content="#0b0d10" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Safe Game</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/styles/app.css
+++ b/styles/app.css
@@ -13,13 +13,17 @@
   --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
+html {
+  background-color: var(--bg);
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  height: 100vh;
+  min-height: 100vh;
   background:
     radial-gradient(
       1200px 600px at 15% -10%,
@@ -53,17 +57,32 @@ body {
   line-height: 1.6;
 }
 
+@supports (height: 100dvh) {
+  body {
+    min-height: 100dvh;
+  }
+}
+
 #app {
   height: 100%;
   width: 100%;
   display: flex;
   justify-content: center;
+  align-items: stretch;
   padding: 48px 16px;
+  padding-top: calc(48px + env(safe-area-inset-top));
+  padding-bottom: calc(48px + env(safe-area-inset-bottom));
+  padding-left: calc(16px + env(safe-area-inset-left));
+  padding-right: calc(16px + env(safe-area-inset-right));
 }
 
 @media (max-width: 600px) {
   #app {
     padding: 24px 12px;
+    padding-top: calc(24px + env(safe-area-inset-top));
+    padding-bottom: calc(24px + env(safe-area-inset-bottom));
+    padding-left: calc(12px + env(safe-area-inset-left));
+    padding-right: calc(12px + env(safe-area-inset-right));
   }
 }
 
@@ -81,6 +100,7 @@ body {
   flex-direction: column;
   gap: 16px;
   position: relative;
+  min-height: 0;
 }
 
 .safe-panel:hover {
@@ -97,6 +117,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-height: 0;
 }
 
 .safe-top {


### PR DESCRIPTION
## Summary
- extend the viewport and PWA meta tags so the background covers the OS status bar on mobile
- update layout spacing to honor safe-area insets and dynamic viewport units, eliminating page scroll on phones
- ensure the safe panel and its content flexboxes can shrink so only the text area scrolls when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03af4d04083278dedff735a8f0b7c