### PR TITLE
Disable mobile page scrolling

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -17,9 +17,19 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  overflow: hidden;
+  overscroll-behavior: none;
   background:
     radial-gradient(
       1200px 600px at 15% -10%,
@@ -55,9 +65,11 @@ body {
 
 #app {
   height: 100%;
+  min-height: 100%;
   width: 100%;
   display: flex;
   justify-content: center;
+  overflow: hidden;
   padding: 48px 16px;
 }
 
@@ -81,6 +93,8 @@ body {
   flex-direction: column;
   gap: 16px;
   position: relative;
+  max-height: 100%;
+  overflow: auto;
 }
 
 .safe-panel:hover {


### PR DESCRIPTION
## Summary
- prevent the main document from scrolling on mobile by locking the viewport height and hiding overflow
- constrain the app shell and safe panel to the viewport and allow the panel to scroll internally when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d056137b048327a11cab047ea19ef8