### PR TITLE
Adjust open safe action buttons layout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -719,8 +719,6 @@ function renderOpen(): HTMLElement {
 
   const content = document.createElement('div');
   content.className = 'safe-content';
-  const top = document.createElement('div');
-  top.className = 'safe-top';
 
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
@@ -749,19 +747,6 @@ function renderOpen(): HTMLElement {
     saveSnapshot(snapshot);
   });
 
-  const textBtn = document.createElement('button');
-  textBtn.textContent = t('insertText');
-  textBtn.addEventListener('click', () => {
-    textarea.focus();
-  });
-  top.appendChild(textBtn);
-
-  const imageBtn = document.createElement('button');
-  imageBtn.textContent = hasImage ? t('replaceImage') : t('chooseImage');
-  imageBtn.addEventListener('click', () => fileInput.click());
-  top.appendChild(imageBtn);
-
-  content.appendChild(top);
   content.appendChild(textarea);
   content.appendChild(fileInput);
 
@@ -786,6 +771,15 @@ function renderOpen(): HTMLElement {
 
   panel.appendChild(content);
 
+  const actions = document.createElement('div');
+  actions.className = 'safe-actions';
+
+  const imageBtn = document.createElement('button');
+  imageBtn.className = 'close-btn image-action-btn';
+  imageBtn.textContent = hasImage ? t('replaceImage') : t('chooseImage');
+  imageBtn.addEventListener('click', () => fileInput.click());
+  actions.appendChild(imageBtn);
+
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
   closeBtn.textContent = t('closeSafe');
@@ -800,7 +794,8 @@ function renderOpen(): HTMLElement {
     const pinHash = await hashPin(pin);
     dispatch({ type: 'close', pinHash, now: Date.now() });
   });
-  panel.appendChild(closeBtn);
+  actions.appendChild(closeBtn);
+  panel.appendChild(actions);
 
   return panel;
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -113,28 +113,21 @@ body {
   gap: 12px;
 }
 
-.safe-top {
+.safe-actions {
   display: flex;
   gap: 12px;
 }
 
-.safe-top button {
-  flex: 1;
-  padding: 8px 12px;
-  border-radius: 10px;
-  background: var(--panel-bright);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  color: var(--txt);
-  font-weight: 600;
-  box-shadow: inset 0 0 8px rgba(45, 212, 191, 0.4);
-  transition:
-    box-shadow 0.2s,
-    border-color 0.2s;
+.safe-actions .close-btn {
+  flex: 3 1 0%;
 }
 
-.safe-top button:hover {
-  border-color: rgba(255, 255, 255, 0.16);
-  box-shadow: inset 0 0 8px rgba(45, 212, 191, 0.6);
+.safe-actions .image-action-btn {
+  flex: 1 1 0%;
+}
+
+.safe-actions button {
+  width: 100%;
 }
 
 .close-btn {


### PR DESCRIPTION
## Summary
- remove the redundant “insert text” button from the open safe panel
- move the image action button next to the close button and size them to a 25/75 split

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06aceaa34832797ef65d694d78288